### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/preacherlemon/ad05e78a-b0ba-4f6c-b2f0-c0b58845c120/1292b433-22e7-497b-88a6-d0d8e387a6e6/_apis/work/boardbadge/fcc2d841-b457-453a-af44-d919a15edc93)](https://dev.azure.com/preacherlemon/ad05e78a-b0ba-4f6c-b2f0-c0b58845c120/_boards/board/t/1292b433-22e7-497b-88a6-d0d8e387a6e6/Microsoft.RequirementCategory)
 # Tic Tac Toe Game
 
 Learn GitHub Actions through a fun little game.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/preacherlemon/ad05e78a-b0ba-4f6c-b2f0-c0b58845c120/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.